### PR TITLE
Allow to pass S3 bucket and/or key name from another stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1 - 2018-08-29
+
+* Resolve S3 bucket/key values if these come from another resolver.
+
 ## v0.1 - 2018-07-18
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ As hook definition, resolver also has **auto-discovery** and **direct** modes.
         ObjectVersion: !s3_version <s3_bucket>/<s3_key>
     ```
 
+* S3 bucket/key names come from another stack:
+
+    ```yaml
+    sceptre_user_data:
+        Code:
+            S3Bucket: !stack_output my-other-stack::BucketName
+            S3Key: !stack_output my-other-stack::KeyName
+            S3ObjectVersion: !s3_version
+    ```
+
 ### Function Makefile
 
 Each function has own `Makefile` file inside it's root.

--- a/hooks/s3_package.py
+++ b/hooks/s3_package.py
@@ -1,6 +1,7 @@
 import hashlib, os, subprocess, zipfile
 from base64 import b64encode
 from sceptre.hooks import Hook
+from sceptre.resolvers import Resolver
 from botocore.exceptions import ClientError
 from datetime import datetime
 from shutil import rmtree
@@ -49,6 +50,14 @@ class S3Package(Hook):
             raise Exception(
                 "S3 bucket/key could not be parsed nor from the argument, neither from sceptre_user_data['Code']"
             )
+
+        if isinstance(s3_bucket, Resolver):
+            s3_bucket = s3_bucket.resolve()
+            self.logger.debug("[{}] resolved S3 bucket value to {}".format(self.NAME, s3_bucket))
+
+        if isinstance(s3_key, Resolver):
+            s3_key = s3_key.resolve()
+            self.logger.debug("[{}] resolved S3 key value to {}".format(self.NAME, s3_key))
 
         fn_dist_dir = os.path.join(fn_root_dir, self.TARGET)
 


### PR DESCRIPTION
Covers linked configuration:

```yaml
sceptre_user_data:
    Code:
        S3Bucket: !stack_output my-other-stack::BucketName
        S3Key: !stack_output my-other-stack::KeyName
        S3ObjectVersion: !s3_version
```