### PR TITLE
Create folders if necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ plugins:
 ifeq (, $(TARGET))
 	$(error Please specity TARGET= value)
 endif
+	/bin/test -d "$(TARGET)/hooks" || mkdir -p "$(TARGET)/hooks"
+	/bin/test -d "$(TARGET)/resolvers" || mkdir -p "$(TARGET)/resolvers"
 	/bin/cp -f hooks/s3_package.py "$(TARGET)/hooks/"
 	/bin/cp -f resolvers/s3_version.py "$(TARGET)/resolvers/"
 


### PR DESCRIPTION
The 'make plugins' command fails if the TARGET hook and resolver
folders don't exist.  Check for the directories and create them
if necessary before copying files.