### PR TITLE
Script doesn't wait until Make Command finished

### DIFF
--- a/hooks/s3_package.py
+++ b/hooks/s3_package.py
@@ -5,6 +5,7 @@ from sceptre.resolvers import Resolver
 from botocore.exceptions import ClientError
 from datetime import datetime
 from shutil import rmtree
+import subprocess
 
 try:
     from StringIO import StringIO as BufferIO
@@ -67,10 +68,11 @@ class S3Package(Hook):
             )
         )
 
-        # just need return code from make command
-        retcode = os.system("make -C {} &> /dev/null".format(fn_root_dir))
+        p = subprocess.Popen(["make -C {} &> /dev/null".format(fn_root_dir)], bufsize=2048, shell=True, stderr=subprocess.PIPE, close_fds=True)
+        p.wait()
+        stderr = p.stderr.read()
 
-        if retcode != 0:
+        if len(stderr) != 0:
             raise Exception("Failed to make dependencies, debug command manually.")
 
         self.logger.debug(


### PR DESCRIPTION
In my environment, the os.system command isn't blocking call.
So, I replace os.system by subprocess module.

With os.system command:

```
vagrant@ubuntu-bionic:/vagrant/sceptre-zip-code-s3$ python --version
Python 2.7.15rc1
vagrant@ubuntu-bionic:/vagrant/sceptre-zip-code-s3$ 
vagrant@ubuntu-bionic:/vagrant/sceptre-zip-code-s3$  sceptre launch-env example/serverless
[2018-09-11 11:15:11] - sceptre.stack - example/serverless/lambda-role - Launching stack
[2018-09-11 11:15:12] - sceptre.stack - example/serverless/lambda-role - Stack is in the PENDING state
[2018-09-11 11:15:12] - sceptre.stack - example/serverless/lambda-role - Creating stack
[2018-09-11 11:15:13] - sceptre.stack - 2018-09-11T11:15:12+00:00 example/serverless/lambda-role sceptre-zip-code-s3-example-serverless-lambda-role AWS::CloudFormation::Stack CREATE_IN_PROGRESS User Initiated
[2018-09-11 11:15:17] - sceptre.stack - 2018-09-11T11:15:15+00:00 example/serverless/lambda-role Role AWS::IAM::Role CREATE_IN_PROGRESS 
[2018-09-11 11:15:17] - sceptre.stack - 2018-09-11T11:15:16+00:00 example/serverless/lambda-role Role AWS::IAM::Role CREATE_IN_PROGRESS Resource creation Initiated
[2018-09-11 11:15:30] - sceptre.stack - 2018-09-11T11:15:27+00:00 example/serverless/lambda-role Role AWS::IAM::Role CREATE_COMPLETE 
[2018-09-11 11:15:30] - sceptre.stack - 2018-09-11T11:15:29+00:00 example/serverless/lambda-role sceptre-zip-code-s3-example-serverless-lambda-role AWS::CloudFormation::Stack CREATE_COMPLETE 
[2018-09-11 11:15:34] - sceptre.stack - example/serverless/lambda-py2-deps - Launching stack
[2018-09-11 11:15:34] - sceptre.stack - example/serverless/lambda-py3-deps-custom - Launching stack
[2018-09-11 11:15:34] - sceptre.stack - example/serverless/lambda-py2-deps - Stack is in the PENDING state
[2018-09-11 11:15:34] - sceptre.hooks - [s3_package] making dependencies with 'make -C src/example/lambda-py2-deps' command, output hidden.
make: Entering directory '/vagrant/sceptre-zip-code-s3/src/example/lambda-py2-deps'
[2018-09-11 11:15:34] - sceptre.environment - Stack example/serverless/lambda-py2-deps failed to launch
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/sceptre/environment.py", line 252, in _manage_stack_build
    status = getattr(stack, command)()
  File "/usr/local/lib/python2.7/dist-packages/sceptre/stack.py", line 281, in launch
    status = self.create()
  File "/usr/local/lib/python2.7/dist-packages/sceptre/hooks/__init__.py", line 69, in decorated
    execute_hooks(self.hooks.get("before_" + func.__name__))
  File "/usr/local/lib/python2.7/dist-packages/sceptre/hooks/__init__.py", line 57, in execute_hooks
    hook.run()
  File "/vagrant/sceptre-zip-code-s3/hooks/s3_package.py", line 100, in run
    rmtree(fn_dist_dir)
  File "/usr/lib/python2.7/shutil.py", line 253, in rmtree
    onerror(os.listdir, path, sys.exc_info())
  File "/usr/lib/python2.7/shutil.py", line 251, in rmtree
    names = os.listdir(path)
OSError: [Errno 2] No such file or directory: 'src/example/lambda-py2-deps/dist'
pip2 install -U -t dist -r requirements.txt | grep -i 'installed'
[2018-09-11 11:15:35] - sceptre.stack - example/serverless/lambda-py3-deps-custom - Stack is in the PENDING state
[2018-09-11 11:15:35] - sceptre.hooks - [s3_package] making dependencies with 'make -C src/example/lambda-py3-deps' command, output hidden.
[2018-09-11 11:15:35] - sceptre.environment - Stack example/serverless/lambda-py3-deps-custom failed to launch
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/sceptre/environment.py", line 252, in _manage_stack_build
    status = getattr(stack, command)()
  File "/usr/local/lib/python2.7/dist-packages/sceptre/stack.py", line 281, in launch
    status = self.create()
  File "/usr/local/lib/python2.7/dist-packages/sceptre/hooks/__init__.py", line 69, in decorated
    execute_hooks(self.hooks.get("before_" + func.__name__))
  File "/usr/local/lib/python2.7/dist-packages/sceptre/hooks/__init__.py", line 57, in execute_hooks
    hook.run()
  File "/vagrant/sceptre-zip-code-s3/hooks/s3_package.py", line 100, in run
    rmtree(fn_dist_dir)
  File "/usr/lib/python2.7/shutil.py", line 253, in rmtree
    onerror(os.listdir, path, sys.exc_info())
  File "/usr/lib/python2.7/shutil.py", line 251, in rmtree
    names = os.listdir(path)
OSError: [Errno 2] No such file or directory: 'src/example/lambda-py3-deps/dist'
make: Entering directory '/vagrant/sceptre-zip-code-s3/src/example/lambda-py3-deps'
pip3 install -U -t dist -r requirements.txt | grep -i 'installed'
bash: pip3: command not found
Makefile:10: recipe for target 'all' failed
make: *** [all] Error 1
make: Leaving directory '/vagrant/sceptre-zip-code-s3/src/example/lambda-py3-deps'
...
```

With subprocess module:

```
vagrant@ubuntu-bionic:/vagrant/sceptre-zip-code-s3$ sceptre create-stack example/serverless lambda-py2-deps
[2018-09-11 11:38:08] - sceptre.hooks - [s3_package] making dependencies with 'make -C src/example/lambda-py2-deps' command, output hidden.
make: Entering directory '/vagrant/sceptre-zip-code-s3/src/example/lambda-py2-deps'
pip2 install -U -t dist -r requirements.txt | grep -i 'installed'
Successfully installed ruamel.ordereddict-0.4.13 ruamel.yaml-0.15.40
/bin/cp -f helper.py index.py dist/
# Files for distribution:
  helper.py
  index.py
  ruamel.ordereddict-0.4.13-py2.7-nspkg.pth
  ruamel.yaml-0.15.40-py2.7-nspkg.pth
  ruamel/ordereddict/__init__.py
  ruamel/yaml/comments.py
  ruamel/yaml/compat.py
  ruamel/yaml/composer.py
  ruamel/yaml/configobjwalker.py
  ruamel/yaml/constructor.py
  ruamel/yaml/cyaml.py
  ruamel/yaml/dumper.py
  ruamel/yaml/emitter.py
  ruamel/yaml/error.py
  ruamel/yaml/events.py
  ruamel/yaml/loader.py
  ruamel/yaml/main.py
  ruamel/yaml/nodes.py
  ruamel/yaml/parser.py
  ruamel/yaml/reader.py
  ruamel/yaml/representer.py
  ruamel/yaml/resolver.py
  ruamel/yaml/scalarfloat.py
  ruamel/yaml/scalarint.py
  ruamel/yaml/scalarstring.py
  ruamel/yaml/scanner.py
  ruamel/yaml/serializer.py
  ruamel/yaml/timestamp.py
  ruamel/yaml/tokens.py
  ruamel/yaml/util.py
  ruamel/yaml/__init__.py
make: Leaving directory '/vagrant/sceptre-zip-code-s3/src/example/lambda-py2-deps'
[2018-09-11 11:38:11] - sceptre.hooks - [s3_package] uploading src/example/lambda-py2-deps/dist to s3://fabio-cloudformation/lambda/example-py2-deps.zip
[2018-09-11 11:38:12] - sceptre.stack - example/serverless/lambda-py2-deps - Creating stack
```
